### PR TITLE
Add printf fallback when mq.printf unavailable

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -49,7 +49,12 @@ local function now()
 end
 
 local function printf(level, msg, ...)
-    mq.printf('\aw[AIO]\ax [\ag%s\ax] %s', level, string.format(msg, ...))
+    local formatted = string.format(msg, ...)
+    if mq and mq.printf then
+        mq.printf('\aw[AIO]\ax [\ag%s\ax] %s', level, formatted)
+    else
+        print(string.format('[AIO] [%s] %s', level, formatted))
+    end
 end
 
 local configDir = mq.configDir or mq.TLO.MacroQuest.Path.Config()


### PR DESCRIPTION
## Summary
- add a fallback logger that uses Lua's print when mq.printf is missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfea659ad4832e86652de79b442ec1